### PR TITLE
Add New Game button for resetting chessboard

### DIFF
--- a/client/components/ChessboardComponent.js
+++ b/client/components/ChessboardComponent.js
@@ -130,6 +130,10 @@ function ChessboardComponent(props) {
     }, [chessInstanceRef, setFen, setBoardState, updateDisplayStatus, getGameStatus, setSelectedSquareId, setLegalMovesForSelected, setMoveEvaluations, setActivePieceDots, triggerEngineAnalysis]);
 
     const handleNewGame = useCallback(() => {
+        const chess = chessInstanceRef.current;
+        if (chess && typeof chess.reset === 'function') {
+            chess.reset();
+        }
         loadFenAndUpdateBoard(initialFenFromProps);
     }, [loadFenAndUpdateBoard, initialFenFromProps]);
 
@@ -139,13 +143,14 @@ function ChessboardComponent(props) {
         const btn = document.createElement('button');
         btn.textContent = 'New Game';
         btn.id = 'new-game-button';
+        btn.type = 'button';
         btn.addEventListener('click', handleNewGame);
         boardEl.insertAdjacentElement('afterend', btn);
         newGameButtonRef.current = btn;
         return () => {
             btn.removeEventListener('click', handleNewGame);
         };
-    }, [boardState, handleNewGame]);
+    }, [handleNewGame]);
     
     // --- Initialization Effect ---
     useEffect(() => {

--- a/client/index.html
+++ b/client/index.html
@@ -46,13 +46,32 @@
         .status-message { margin-top: 10px; padding: 8px 12px; background-color: #374151; /* Tailwind gray-700 */ color: #e0e0e0; border-radius: 5px; font-size: clamp(0.8em, 2vw, 0.9em); min-height: 36px; text-align: center; width: 100%; max-width: 560px; box-sizing: border-box; line-height: 1.4; }
         .error-message { background-color: #d9534f; color: white; }
         .evaluation-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); min-width: 60%; max-width: 90%; padding: 2px 4px; font-size: clamp(10px, 2.2vw, 14px); font-weight: bold; color: white; text-align: center; opacity: 0.9; border-radius: 4px; box-sizing: border-box; line-height: 1.2; pointer-events: none; z-index: 20; white-space: nowrap; }
-        .eval-text-best { background-color: rgba(52, 152, 219, 0.8); } 
+        .eval-text-best { background-color: rgba(52, 152, 219, 0.8); }
         .eval-text-good { background-color: rgba(39, 174, 96, 0.75); }
         .eval-text-neutral { background-color: rgba(144, 238, 144, 0.7); } 
         .eval-text-bad { background-color: rgba(241, 196, 15, 0.75); }
         .eval-text-blunder { background-color: rgba(231, 76, 60, 0.8); } 
         .eval-text-mate-positive { background-color: rgba(41, 128, 185, 0.85); }
         .eval-text-mate-negative { background-color: rgba(192, 57, 43, 0.9); }
+
+        /* New Game button styling */
+        #new-game-button {
+            display: block;
+            margin: 10px auto 0 auto;
+            padding: 8px 16px;
+            background-color: #374151;
+            color: #e5e7eb;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            width: 100%;
+            max-width: 560px;
+            font-weight: 600;
+        }
+
+        #new-game-button:hover {
+            background-color: #4b5563;
+        }
 
         /* --- ChatMessage Component Styles (Consolidated) --- */
         /* These styles are intended for elements rendered by ChatMessageComponent.js */


### PR DESCRIPTION
## Summary
- dynamically insert a `New Game` button below the board
- clicking the button reloads the initial board state via existing logic

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a810aa8083208e46610582531f5f